### PR TITLE
Upgraded to MediatR 12.0.0 -> https://jimmybogard.com/mediatr-12-0-re…

### DIFF
--- a/MediatR.Behaviors.Authorization/MediatR.Behaviors.Authorization.csproj
+++ b/MediatR.Behaviors.Authorization/MediatR.Behaviors.Authorization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MediatR.Behaviors.Authorization</AssemblyName>
     <Authors>Austin Davies</Authors>
     <Description>A simple request authorization package that allows you to build and run request specific authorization requirements before your request handler is called.</Description>
@@ -14,9 +14,9 @@
     <RepositoryType></RepositoryType>
     <PackageProjectUrl>https://github.com/AustinDavies/MediatR.Behaviors.Authorization</PackageProjectUrl>
     <PackageReleaseNotes>Initial release</PackageReleaseNotes>
-    <Version>11.1.1</Version>
-    <AssemblyVersion>11.1.1.0</AssemblyVersion>
-    <FileVersion>11.1.1.0</FileVersion>
+    <Version>12.0.0</Version>
+    <AssemblyVersion>12.0.0.0</AssemblyVersion>
+    <FileVersion>12.0.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
@@ -29,9 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="11.1.0" />
-    <PackageReference Include="MediatR.Contracts" Version="1.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.0" />
+    <PackageReference Include="MediatR.Contracts" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/GlobalAuthorizerExample/GlobalAuthorizerExample.csproj
+++ b/examples/GlobalAuthorizerExample/GlobalAuthorizerExample.csproj
@@ -8,9 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="11.1.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 

--- a/examples/GlobalAuthorizerExample/Program.cs
+++ b/examples/GlobalAuthorizerExample/Program.cs
@@ -21,7 +21,7 @@ namespace GlobalAuthorizerExample
             IServiceCollection services = new ServiceCollection();
 
             services.AddScoped<ICurrentUserService>(provider => _exampleCurrentUserService);
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
 
             services.AddMediatorAuthorization(Assembly.GetExecutingAssembly());
             services.AddAuthorizersFromAssembly(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
Changes:
- Upgraded to MediatR v12
- Changed build target from .NET standard 2.1 to .NET standard 2.0 to be compatible with .NET framework

Release notes for MediatR v12 can be found [here](https://jimmybogard.com/mediatr-12-0-released/).
